### PR TITLE
Bugfix for notdeft-xapian on Ubuntu

### DIFF
--- a/xapian/Makefile
+++ b/xapian/Makefile
@@ -7,7 +7,7 @@ default : build
 build : $(PROGRAM)
 
 $(PROGRAM) : notdeft-xapian.cc
-	g++ -o $@ -std=c++11 -Wall `pkg-config --cflags --libs tclap` `xapian-config --cxxflags --libs` $<
+	g++ -o $@ $< -std=c++11 -Wall `pkg-config --cflags --libs tclap` `xapian-config --cxxflags --libs`
 
 clean :
 	-rm $(PROGRAM)


### PR DESCRIPTION
The invocation of g++ needs to have the Xapian-config flags coming
last. Don't know why, but it works.