### PR TITLE
Automate installation

### DIFF
--- a/notdeft-xapian.el
+++ b/notdeft-xapian.el
@@ -179,6 +179,41 @@ non-directory filename, all descending, based on the
 	     (split-string s "\n" t))))
       files)))
 
+(defvar notdeft-xapian-install-buffer-name " *Install notdeft-xapian"
+  "Name of the buffer used for compiling notdeft-xapian.")
+
+(defvar notdeft-directory-path
+  (shell-quote-argument (file-name-directory (file-truename (locate-library "notdeft"))))
+  "Directory path for notdeft.")
+
+(defvar notdeft-xapian-executeable-path
+  (shell-quote-argument (concat notdeft-directory-path "xapian/notdeft-xapian"))
+  "Path for the notdeft-xapian executeable.")
+
+(defvar notdeft-disable-notdeft-xapian-compilation nil
+  "Disables the compilation of notdeft-xapian, when the notdeft-xapian
+  executeable does not exist and notdeft is loaded.")
+
+(defun notdeft-make-notdeft-xapian ()
+  "This function compiles the notdeft-xapian application."
+  (interactive)
+  (let* ((change-dir (concat "cd " notdeft-directory-path "xapian;"))
+         (make-commands (concat change-dir "make")))
+    (unless (file-executable-p notdeft-xapian-executeable-path)
+      (let* ((buffer (get-buffer-create notdeft-xapian-install-buffer-name)))
+        (pop-to-buffer notdeft-xapian-install-buffer-name)
+        (if (zerop (call-process "sh" nil buffer t "-c" make-commands))
+            (message "Compilation of `notdeft-xapian' succeeded!")
+          (error "Compilation of `notdeft-xapian' failed!"))))))
+
+(defun notdeft-make-notdeft-xapian-when-not-found ()
+  "Run `notdeft-make-notdeft-xapian', when the notdeft-xapian executable does not exist."
+  (if (and (not (file-exists-p notdeft-xapian-executeable-path))
+           (not notdeft-disable-notdeft-xapian-compilation))
+      (notdeft-make-notdeft-xapian)))
+
+(add-hook 'notdeft-load-hook 'notdeft-make-notdeft-xapian-when-not-found)
+
 (provide 'notdeft-xapian)
 
 ;;; notdeft-xapian.el ends here


### PR DESCRIPTION
Hey,

First of all, thank you for creating this package! 

In order to simplify the installation, I added the function `notdeft-make-notdeft-xapian-when-not-found`, which automatically builds the `xapian-notdeft` application, when it is not already built and the variable `notdeft-disable-notdeft-xapian-compilation` is `nil` (default). I added this function to the `notdeft-load-hook` in order to automate the installation process of this package.

Having this functionality would make this package compatible with emacs package managers like [use-package](https://github.com/jwiegley/use-package) or [straight](https://github.com/raxod502/straight.el) and simplify the installation.

Here is an example of configuring notdeft with straight:

``` emacs-lisp
(use-package notdeft
     :straight (:host github
                :repo "hasu/notdeft"
                :branch "xapian"
                :files ("*" (:exclude "images" "Makefile" "web" "README.org"))))
```

This PR would also enable publishing this package to [melpa](https://melpa.org/):

``` emacs-lisp
;; melpa recipe
(notdeft :fetcher github
	 :repo "hasu/notdeft"
         :branch "xapian"
         :files ("*" (:exclude "images" "Makefile" "web" "README.org")))
```
[Here](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org) is more information about adding this package to  [melpa](https://melpa.org/) if you are interested in doing so.