### PR TITLE
`C-c C-d` notdeft-delete-file to a recycle bin

### DIFF
--- a/notdeft.el
+++ b/notdeft.el
@@ -1911,7 +1911,10 @@ deleted file's buffer, if any."
 	(when (y-or-n-p
 	       (concat "Delete file " old-file-nd "? "))
 	  (when (file-exists-p old-file)
-	    (delete-file old-file))
+	    
+	    ;; ~C-c C-d~: trash the file to a reycle bin (instead of deleting it outright) by adding the optional argument  "t"
+	    (delete-file old-file t))
+	  
 	  (delq old-file notdeft-current-files)
 	  (delq old-file notdeft-all-files)
 	  (notdeft-changed--fs 'files (list old-file))


### PR DESCRIPTION
Dear Tero,

First, thank you so much for the wonderful package, which I have been using for over half a year now. NotDeft is very fast and reliable, and I am so happy to chance upon  it! :smile:  (https://icaruszhu.github.io/chen/2020/09/20/To-Deft-or-NotDeft/)

However, very recently, I deleted a deft note (using`C-c C-d`) by mistake. To my dismay, I could not retrieve it from the recycle bin.  (BTW,I am using Ubuntu Studio 20.04 XFCE, and the recycle bin is called "Wastebasket") . 

I looked at the elisp source file `notdeft.el` and found the function `notdeft-delete-file` used `(delete-file old-file)` without an optional `TRASH` argument. So I simply add  `t`, which will move the deleted note to a recycle bin.

```
	    (delete-file old-file t)
```

Would you consider this pull request?  I guess this tiny change might be useful for other NotDeft users (just in case they delete a file by mistake). Thank you again! 

====
p.s.
I also have `(setq delete-by-moving-to-trash t)` in my `init.el`.



