### PR TITLE
translate filter-increment input chars using current input method

### DIFF
--- a/notdeft.el
+++ b/notdeft.el
@@ -2378,8 +2378,11 @@ If STR is nil, clear the filter."
 In particular, update `notdeft-current-files'.
 Get the character from the variable `last-command-event'."
   (interactive)
-  (let ((char (let ((buffer-read-only nil))
-                (car (funcall input-method-function last-command-event)))))
+  (let ((char (if input-method-function
+                  (let ((buffer-read-only nil))
+                    (car (funcall input-method-function last-command-event)))
+                last-command-event
+                )))
     (when (= char ?\S-\ )
       (setq char ?\s))
     (setq char (char-to-string char))

--- a/notdeft.el
+++ b/notdeft.el
@@ -2378,7 +2378,8 @@ If STR is nil, clear the filter."
 In particular, update `notdeft-current-files'.
 Get the character from the variable `last-command-event'."
   (interactive)
-  (let ((char last-command-event))
+  (let ((char (let ((buffer-read-only nil))
+                (car (funcall input-method-function last-command-event)))))
     (when (= char ?\S-\ )
       (setq char ?\s))
     (setq char (char-to-string char))


### PR DESCRIPTION
The incremental filter, as it is, ignores the current input method, so when we `toggle-input-method` to a non-ASCII one (for example, Cyrillic or Greek), only the corresponding ASCII characters still appear in the filter input line. The problem also exists in the original "deft" package too. This small fix resolves the issue. It works well for "Russian" input method, but should also work for other similar input methods using quail minor mode.

Thank you for your wonderful package. Good luck to you.